### PR TITLE
update deb script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 endif()
 
 set(PROJECT_NAME          "kra_gdk_pixbuf")
-set(PROJECT_VERSION       "1.0.0")
+set(PROJECT_VERSION       "1.0.1")
 set(PROJECT_DESCRIPTION   "GDK pixbuf loader module for Krita documents (kra and ora image formats) support in image viewers like Eye of Gnome")
 set(PROJECT_COPYRIGHT     "Copyright (C) ${CURRENT_YEAR}")
 set(PROJECT_CONTACT       "Gregg Jansen van Vüren <vurentjie@gmail.com>")

--- a/script/postinst
+++ b/script/postinst
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-PIXBUF_CACHE_CMD=""
+PIXBUF_CACHE_CMD="/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders"
 
-if [[ ! -z "$(command -v which)" ]]; then
-  PIXBUF_CACHE_CMD="$(which gdk-pixbuf-query-loaders)"
-fi
+if [[ ! -e "${PIXBUF_CACHE_CMD}" ]]; then
+  if [[ ! -z "$(command -v which)" ]]; then
+    PIXBUF_CACHE_CMD="$(which gdk-pixbuf-query-loaders)"
+  fi
 
-if [[ ! -z "$(command -v pkg-config)" ]]; then
-  if [[ ! -e "${PIXBUF_CACHE_CMD}" ]]; then
-    PIXBUF_CACHE_CMD=$(pkg-config gdk-pixbuf-2.0 --variable gdk_pixbuf_query_loaders)
+  if [[ ! -z "$(command -v pkg-config)" ]]; then
+    if [[ ! -e "${PIXBUF_CACHE_CMD}" ]]; then
+      PIXBUF_CACHE_CMD=$(pkg-config gdk-pixbuf-2.0 --variable gdk_pixbuf_query_loaders)
+    fi
   fi
 fi
 

--- a/script/postrm
+++ b/script/postrm
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-PIXBUF_CACHE_CMD=""
+PIXBUF_CACHE_CMD="/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders"
 
-if [[ ! -z "$(command -v which)" ]]; then
-  PIXBUF_CACHE_CMD="$(which gdk-pixbuf-query-loaders)"
-fi
+if [[ ! -e "${PIXBUF_CACHE_CMD}" ]]; then
+  if [[ ! -z "$(command -v which)" ]]; then
+    PIXBUF_CACHE_CMD="$(which gdk-pixbuf-query-loaders)"
+  fi
 
-if [[ ! -z "$(command -v pkg-config)" ]]; then
-  if [[ ! -e "${PIXBUF_CACHE_CMD}" ]]; then
-    PIXBUF_CACHE_CMD=$(pkg-config gdk-pixbuf-2.0 --variable gdk_pixbuf_query_loaders)
+  if [[ ! -z "$(command -v pkg-config)" ]]; then
+    if [[ ! -e "${PIXBUF_CACHE_CMD}" ]]; then
+      PIXBUF_CACHE_CMD=$(pkg-config gdk-pixbuf-2.0 --variable gdk_pixbuf_query_loaders)
+    fi
   fi
 fi
 


### PR DESCRIPTION
update deb script to first check the known location for gdk-pixbuf-query-loaders. 
this avoids the case where pkg-config is not pre-installed. 

